### PR TITLE
Usando `git describe --tags` para obtener la versión del paquete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint pytest mypy kareltest
+.PHONY: test lint pytest mypy kareltest build upload
 
 test: pytest lint mypy kareltest
 
@@ -18,3 +18,10 @@ kareltest:
 		echo "Expected result to be 1, got '$${RESULT}'"; \
 		exit 1; \
 	fi
+
+build:
+	rm -rf dist/*
+	python3 setup.py sdist bdist_wheel
+
+upload:
+	python3 -m twine upload --repository testpypi dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 """Setup tools for libkarel."""
 
+import subprocess
 import setuptools  # type: ignore
 
 with open("README.md", "r") as fh:
@@ -7,13 +8,14 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='libkarel',
-    version='1.0.0',
+    version=subprocess.check_output(['/usr/bin/git', 'describe', '--tags'],
+                                    universal_newlines=True),
     author='omegaUp',
     author_email='lhchavez@omegaup.org',
     description='Utilities for validating karel.js test cases',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url='https://github.com/omegaup/karel.js',
+    url='https://github.com/omegaup/libkarel',
     packages=setuptools.find_packages(),
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Este cambio hace que ya no sea necesario cambiar la versión a mano, ya
que GitHub lo hará por nosotros.