### PR TITLE
Automatizando el proceso de construcción y publicación de paquetes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -22,3 +24,26 @@ jobs:
           WITH_V: true
           DEFAULT_BUMP: patch
           INITIAL_VERSION: 1.0.0
+
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build setuptools-scm
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Descripción

En este cambio se modifica el workflow de los releases, para que cada cambio de versión (al crear un nuevo tag) se realice la construcción y la publicación automática del paquete `.tar.gz` y `*.whl` en PyPi.

## Comments

Aún faltará la creación del secret `PYPI_API_TOKEN`, pero esta acción sólo la puede realizar el administrador del repositorio 