### PR TITLE
Actualizando sistema de construcción para soportar instalaciones editables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ kareltest:
 
 build:
 	rm -rf dist/*
-	python3 setup.py sdist bdist_wheel
+	python3 -m build
 
 upload:
 	python3 -m twine upload --repository testpypi dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm"]
+requires = ["setuptools>=64.0", "setuptools-scm>=8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -20,5 +20,9 @@ dynamic = ["version"]
 
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["libkarel*"]
+
+[tool.setuptools]
+include-package-data = true
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Se corrige el soporte para instalaciones editables modernizando el sistema de construcción. 

Habían quedado pendientes un par de cambios que aún hacían referencia al la configuración anterior (setup.py) los cuales estaban ocasionando errores en el `Makefile` para construir el paquete y ejecutar las pruebas